### PR TITLE
Feature: Field Type text-group

### DIFF
--- a/README.md
+++ b/README.md
@@ -386,6 +386,11 @@ field:
   tag to make it easier to loop over the links entered by the user in your
   templates. See "Link Group Template Tags" below.
 
+* `text-group` - Produces an ordered list of text labels manually entered by the
+  user. Options of this type will have defined for them an additional template
+  tag to make it easier to loop over the text items entered by the user in your
+  templates. See "Text Group Template Tags" below.
+
 * `file` - Allows a user to upload a file, which in turn gets converted into
   an asset. An additional field property is supported for file types:
   `destination` which can be used to customize the path/url of the uploaded
@@ -489,6 +494,49 @@ You can use them like so:
       <mt:Else>
         I have no favorite links.
       </mt:MyFavoritesLinks>
+    </p>
+
+**Text Group Tags**
+
+For each option of type `text-group` that is defined, two template tags are
+defined. The first is the one specified by the user using the `tag` parameter
+associated with the option in the `config.yaml`. This template tag will be
+useless to most users as it will return a JSON encoded data structure
+containing all the links entered by the user.
+
+The second template tag is the useful one. It is called `<TAGNAME>Items`. This
+template tag is a container or block tag that loops over each of the links
+entered by the user. Inside each iteration of the loop the following template
+variables are defined for you:
+
+* `__first__` True only if the current link is the first one in the list.
+* `__last__` - True only if the current link is the last one in the list.
+* `label` - The label associated with the current item.
+
+For example, look at this `config.yaml`:
+
+    my_links:
+        type: text-group
+        label: 'My List'
+        tag: 'MyList'
+
+This will create two template tags:
+
+1. `<$mt:MyList$>`
+2. `<mt:MyListItems></mt:MyListItems>`
+
+You can use them like so:
+
+    <p>My favorite things are: 
+      <mt:MyListItems>
+        <mt:if name="__first__"><ul></mt:if>
+        <li>
+            <$mt:var name="label"$>
+        </li>
+        <mt:if name="__last__"></ul></mt:if>
+      <mt:Else>
+        I have no favorite things.
+      </mt:MyListItems>
     </p>
 
 **Asset Template Tags**

--- a/addons/ConfigAssistant.pack/config.yaml
+++ b/addons/ConfigAssistant.pack/config.yaml
@@ -5,7 +5,7 @@ author_link: http://openmelody.org/
 author_name: "Byrne Reese, Open Melody Software Group"
 description: This plugin provides a simple YAML based framework for creating plugin and theme configuration options.
 version: 2.1.32
-static_version: 11
+static_version: 13
 schema_version: 3
 
 applications:
@@ -65,6 +65,8 @@ config_types:
     handler: $ConfigAssistant::ConfigAssistant::Plugin::type_tagged_entry
   link-group:
     handler: $ConfigAssistant::ConfigAssistant::Plugin::type_link_group
+  text-group:
+    handler: $ConfigAssistant::ConfigAssistant::Plugin::type_text_group
   category:
     handler: $ConfigAssistant::ConfigAssistant::Plugin::type_category
   category_list:

--- a/addons/ConfigAssistant.pack/lib/ConfigAssistant/Init.pm
+++ b/addons/ConfigAssistant.pack/lib/ConfigAssistant/Init.pm
@@ -299,6 +299,26 @@ sub load_tags {
                                         'ConfigAssistant::Plugin', @_ );
                             };
                         } ## end elsif ( $option->{'type'}...)
+                        elsif ( $option->{'type'} eq 'text-group' ) {
+                            $tags->{block}->{ $tag . 'Items' } = sub {
+                                my $blog = $_[0]->stash('blog');
+                                my $bset = $blog->template_set;
+                                $_[0]->stash( 'field', $bset . '_' . $opt );
+                                $_[0]->stash( 'plugin_ns',
+                                              find_theme_plugin($bset)->id );
+                                $_[0]->stash( 'scope', 'blog' );
+                                $_[0]->stash(
+                                           'show_children',
+                                           (
+                                             defined $option->{show_children}
+                                             ? $option->{show_children}
+                                             : 1
+                                           )
+                                );
+                                runner( '_hdlr_field_text_group',
+                                        'ConfigAssistant::Plugin', @_ );
+                            };
+                        } ## end elsif ( $option->{'type'}...)
                         elsif (    $option->{'type'} eq 'category_list'
                                 or $option->{'type'} eq 'folder_list' )
                         {

--- a/addons/ConfigAssistant.pack/static/css/app.css
+++ b/addons/ConfigAssistant.pack/static/css/app.css
@@ -55,11 +55,11 @@ h2#page-title span.star { display: none; }
   background: url(../colorpicker/images/select.png) center;
 }
 
-.field-type-link-group label.link-text {
+.field-type-link-group label.link-text, .field-type-text-group label.link-text {
   padding-right: 10px;
 }
 
-.field-type-link-group a.add-link {
+.field-type-link-group a.add-link, .field-type-text-group a.add-item {
     display: block;
     float: left;
     color: white;

--- a/addons/ConfigAssistant.pack/static/js/options.js
+++ b/addons/ConfigAssistant.pack/static/js/options.js
@@ -50,3 +50,51 @@ function render_link_form(label,url) {
     });
     return e;
 };
+
+// text-group Utility Functions
+function text_handle_edit_click() {
+    var p = jQuery(this).parent();
+    var text = p.find('span.text');
+    if (text.length > 0) {
+        p.replaceWith( render_text_form( text.html() ) );
+    } else {
+        p.before( render_text_form( '' ) );
+        p.hide();
+    }
+    p.parent().find('input.label').focus();
+    return false;
+};
+function render_text(label) {
+    var dom = '<li class="pkg"><span class="text">'+label+'</span> <a class="remove" href="javascript:void(0);"><img src="'+StaticURI+'images/icon_close.png" alt="remove" title="remove" /></a> <a class="edit" href="javascript:void(0);">edit</a></li>';
+    var e = jQuery(dom);
+    e.find('a.edit').click( text_handle_edit_click );
+    e.find('a.remove').click( text_handle_delete_click );
+    return e;
+};
+function text_handle_save_click() {
+    var label = jQuery(this).parent().find('input[class=label]').val();
+    if (!label) { return false; }
+    jQuery(this).parents('ul').find('li.last').show();
+    jQuery(this).parent().replaceWith( render_text(label) );
+    return false;
+};
+function text_handle_delete_click() {
+    jQuery(this).parent().remove(); return false;
+};
+function render_text_form(label,url) {
+    var dom = '<li><label class="link-text">Label: <input type="text" class="label" value="'+(typeof label != 'undefined' ? label : '')+'" /></label> <button>Save</button></li>';
+    var e = jQuery(dom);
+    e.find('button').click( text_handle_save_click ); 
+    e.find('input.label').focus( function() {
+        jQuery(this).bind('keypress', function(event) {
+            if (event.keyCode == 13) {
+                event.stopPropagation();
+                e.find('button').trigger('click');
+                return false;
+            }
+    });
+    }).blur( function() {
+        jQuery(this).unbind('keypress');
+    });
+    return e;
+};


### PR DESCRIPTION
Added a text-group field type that enables the manual creation of a list of text labels. Based on the link-group field type, it is like a list of link labels only, without URLs. Useful for outputting lists of unlinked items.
